### PR TITLE
Added challenge 5 for taster day - flag level text only visible in dark mode

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -223,7 +223,7 @@ const HomePage = () => {
             />
           </div>
           {theme === 'dark' &&
-            <p className="text-lg text-jb-dark-headings font-bold text-center mt-10">
+            <p className="text-xs text-jb-dark-headings font-bold text-center mt-10">
               darkModeSuperior
             </p>
           }


### PR DESCRIPTION
- Added flag text `darkModeSuperior` at bottom of home page
- Flag is only visible when dark mode is toggled