### PR TITLE
Fixing navigation arrows

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -151,6 +151,9 @@ const HomePage = () => {
               loop
               autoplay
               modules={[Pagination, Navigation]}
+              style={{
+                padding: '0 25px'
+              }}
             >
               {featuredJobs.map((job) => (
                 <SwiperSlide key={job.id}>


### PR DESCRIPTION
Added padding to the Swiper container to remove the overlap between the arrows and job listings
![Screenshot 2024-06-22 at 4 42 04 PM](https://github.com/devsoc-unsw/jobsboard/assets/90817386/1ab6b512-a388-4253-8649-2cbb487f1f5c)
